### PR TITLE
Fix header alignment for services

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -100,7 +100,7 @@ const Header: React.FC = () => {
             
             {/* Services Dropdown */}
             <div
-              className="relative pb-2"
+              className="relative"
               onMouseEnter={() => setIsServicesOpen(true)}
               onMouseLeave={() => setIsServicesOpen(false)}
             >


### PR DESCRIPTION
## Summary
- remove extra padding on the services dropdown wrapper so all nav items align

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c69bf924832dbfb562ccaadec007