### PR TITLE
Add fourth hero slide

### DIFF
--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -25,6 +25,12 @@ const HeroSlider: React.FC = () => {
       subtitle: t('heroSlide3Subtitle'),
       highlight: t('heroSlide3Highlight'),
       bgGradient: "from-indigo-600 via-blue-600 to-cyan-600"
+    },
+    {
+      title: t('heroSlide4Title'),
+      subtitle: t('heroSlide4Subtitle'),
+      highlight: t('heroSlide4Highlight'),
+      bgGradient: "from-green-600 via-teal-600 to-cyan-600"
     }
   ];
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -20,6 +20,9 @@ const translations = {
     heroSlide3Title: 'Ваш успіх - наш пріоритет',
     heroSlide3Subtitle: 'Створюємо рішення, які приносять реальні результати та збільшують ваші продажі',
     heroSlide3Highlight: '⚡ Швидка реалізація проектів',
+    heroSlide4Title: 'Інтелектуальні AI-агенти',
+    heroSlide4Subtitle: 'Персоналізовані рішення з використанням передових алгоритмів',
+    heroSlide4Highlight: '🤖 Інноваційні AI-можливості',
     orderNow: 'Замовити зараз',
     viewWork: 'Переглянути роботи',
 
@@ -385,6 +388,9 @@ const translations = {
     heroSlide3Title: 'Your success is our priority',
     heroSlide3Subtitle: 'We create solutions that bring real results and increase your sales',
     heroSlide3Highlight: '⚡ Fast project implementation',
+    heroSlide4Title: 'Intelligent AI agents',
+    heroSlide4Subtitle: 'Personalized solutions using advanced algorithms',
+    heroSlide4Highlight: '🤖 Innovative AI capabilities',
     orderNow: 'Order Now',
     viewWork: 'View Work',
 
@@ -750,6 +756,9 @@ const translations = {
     heroSlide3Title: 'Ваш успех - наш приоритет',
     heroSlide3Subtitle: 'Создаем решения, которые приносят реальные результаты и увеличивают ваши продажи',
     heroSlide3Highlight: '⚡ Быстрая реализация проектов',
+    heroSlide4Title: 'Интеллектуальные AI-агенты',
+    heroSlide4Subtitle: 'Персонализированные решения с использованием передовых алгоритмов',
+    heroSlide4Highlight: '🤖 Инновационные AI-возможности',
     orderNow: 'Заказать сейчас',
     viewWork: 'Посмотреть работы',
 


### PR DESCRIPTION
## Summary
- extend `HeroSlider` with a fourth slide
- localize text for the new slide in all languages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cd5f2dd8832d9f7a3abcbea726f5