### PR TITLE
Add AI agent services

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,7 +58,13 @@ const Header: React.FC = () => {
       '3': t('landingPageTitle'),
       '4': t('corporateWebsiteTitle'),
       '5': t('portfolioSiteTitle'),
-      '6': t('mediaPortalTitle')
+      '6': t('mediaPortalTitle'),
+      '11': t('aiChatAgentTitle'),
+      '12': t('recommendationAgentTitle'),
+      '13': t('analyticsAgentTitle'),
+      '14': t('contentGeneratorTitle'),
+      '15': t('virtualAssistantTitle'),
+      '16': t('monitoringAgentTitle')
     };
     return titleMap[serviceId] || services.find(s => s.id === serviceId)?.title || '';
   };

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -37,6 +37,12 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service, isLarge = true }) =>
       '8': t('printDesignTitle'),
       '9': t('bannerDesignTitle'),
       '10': t('redesignTitle')
+      , '11': t('aiChatAgentTitle'),
+      '12': t('recommendationAgentTitle'),
+      '13': t('analyticsAgentTitle'),
+      '14': t('contentGeneratorTitle'),
+      '15': t('virtualAssistantTitle'),
+      '16': t('monitoringAgentTitle')
     };
     return titleMap[serviceId] || service.title;
   };
@@ -53,6 +59,12 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service, isLarge = true }) =>
       '8': t('printDesignDescription'),
       '9': t('bannerDesignDescription'),
       '10': t('redesignDescription')
+      , '11': t('aiChatAgentDescription'),
+      '12': t('recommendationAgentDescription'),
+      '13': t('analyticsAgentDescription'),
+      '14': t('contentGeneratorDescription'),
+      '15': t('virtualAssistantDescription'),
+      '16': t('monitoringAgentDescription')
     };
     return descriptionMap[serviceId] || service.description;
   };

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -181,6 +181,18 @@ const translations = {
     portfolioSiteDescription: 'Персональний сайт для демонстрації ваших робіт та досягнень',
     mediaPortalTitle: 'Медіа-портал',
     mediaPortalDescription: 'Новинний портал або блог з системою публікацій та коментарів',
+    aiChatAgentTitle: 'AI-чат-агент',
+    aiChatAgentDescription: 'Мультиканальний чат-бот для обробки запитів клієнтів у реальному часі з інтеграцією у месенджери та CRM',
+    recommendationAgentTitle: 'Рекомендаційний агент',
+    recommendationAgentDescription: 'Система персоналізованих рекомендацій товарів чи контенту на основі поведінки користувачів',
+    analyticsAgentTitle: 'Аналітичний AI-агент',
+    analyticsAgentDescription: 'Автоматизована обробка та візуалізація великих даних із прогнозами й звітністю',
+    contentGeneratorTitle: 'Контент-генератор',
+    contentGeneratorDescription: 'AI-інструмент для створення статей, описів товарів та маркетингових текстів',
+    virtualAssistantTitle: 'Віртуальний асистент',
+    virtualAssistantDescription: 'Голосовий або текстовий агент для бронювання, нагадувань і базових консультацій',
+    monitoringAgentTitle: 'Моніторинговий агент',
+    monitoringAgentDescription: 'Система відстеження ключових метрик (сайт, соцмережі, продажі) з миттєвими сповіщеннями',
 
     // Additional Services
     logoDesignTitle: 'Дизайн логотипу',
@@ -371,6 +383,54 @@ const translations = {
     feature6_5: 'Соціальні мережі',
     feature6_6: 'Пошук по сайту',
 
+    // Service features - AI Chat Agent
+    feature11_1: 'Миттєві відповіді 24/7',
+    feature11_2: 'Інтеграція з месенджерами',
+    feature11_3: 'Підтримка декількох мов',
+    feature11_4: 'Аналітика запитів',
+    feature11_5: 'Просте налаштування сценаріїв',
+    feature11_6: 'Зв\'язок з CRM',
+
+    // Service features - Recommendation Agent
+    feature12_1: 'Персоналізовані рекомендації',
+    feature12_2: 'Аналіз поведінки користувачів',
+    feature12_3: 'Інтеграція з каталогом',
+    feature12_4: 'Гнучкі правила',
+    feature12_5: 'Статистика ефективності',
+    feature12_6: 'Масштабованість',
+
+    // Service features - Analytical AI Agent
+    feature13_1: 'Автоматична обробка даних',
+    feature13_2: 'Інтерактивні дашборди',
+    feature13_3: 'Прогнозування трендів',
+    feature13_4: 'Експорт звітів',
+    feature13_5: 'Інтеграція з BI системами',
+    feature13_6: 'Підтримка великих даних',
+
+    // Service features - Content Generator
+    feature14_1: 'Швидке створення статей',
+    feature14_2: 'SEO оптимізовані тексти',
+    feature14_3: 'Різні жанри контенту',
+    feature14_4: 'Інтеграція з CMS',
+    feature14_5: 'Налаштування тону голосу',
+    feature14_6: 'Опис товарів',
+
+    // Service features - Virtual Assistant
+    feature15_1: 'Голосове та текстове управління',
+    feature15_2: 'Нагадування і календар',
+    feature15_3: 'Бронювання зустрічей',
+    feature15_4: 'Відповіді на FAQ',
+    feature15_5: 'Синхронізація зі смартфоном',
+    feature15_6: 'Персоналізовані поради',
+
+    // Service features - Monitoring Agent
+    feature16_1: 'Відстеження трафіку сайту',
+    feature16_2: 'Аналіз соцмереж',
+    feature16_3: 'Контроль продажів',
+    feature16_4: 'Сповіщення про відхилення',
+    feature16_5: 'Звіти в реальному часі',
+    feature16_6: 'Інтеграція з аналітикою',
+
     // Project Description
     projectDescription: 'Опис проекту',
     technologies: 'Технології',
@@ -549,6 +609,18 @@ const translations = {
     portfolioSiteDescription: 'Personal website to showcase your work and achievements',
     mediaPortalTitle: 'Media Portal',
     mediaPortalDescription: 'News portal or blog with publication and comment system',
+    aiChatAgentTitle: 'AI Chat Agent',
+    aiChatAgentDescription: 'Multichannel chatbot handling customer inquiries in real time with messenger and CRM integration',
+    recommendationAgentTitle: 'Recommendation Agent',
+    recommendationAgentDescription: 'Personalized product or content recommendations based on user behavior',
+    analyticsAgentTitle: 'Analytical AI Agent',
+    analyticsAgentDescription: 'Automated processing and visualization of big data with forecasts and reporting',
+    contentGeneratorTitle: 'Content Generator',
+    contentGeneratorDescription: 'AI tool for creating articles, product descriptions and marketing texts',
+    virtualAssistantTitle: 'Virtual Assistant',
+    virtualAssistantDescription: 'Voice or text agent for booking, reminders and basic consultations',
+    monitoringAgentTitle: 'Monitoring Agent',
+    monitoringAgentDescription: 'System for tracking key metrics (website, social media, sales) with instant alerts',
 
     // Additional Services
     logoDesignTitle: 'Logo Design',
@@ -739,6 +811,54 @@ const translations = {
     feature6_5: 'Social networks',
     feature6_6: 'Site search',
 
+    // Service features - AI Chat Agent
+    feature11_1: 'Instant replies 24/7',
+    feature11_2: 'Messenger integration',
+    feature11_3: 'Multi-language support',
+    feature11_4: 'Query analytics',
+    feature11_5: 'Easy scenario setup',
+    feature11_6: 'CRM connection',
+
+    // Service features - Recommendation Agent
+    feature12_1: 'Personalized recommendations',
+    feature12_2: 'User behavior analysis',
+    feature12_3: 'Catalog integration',
+    feature12_4: 'Flexible rules',
+    feature12_5: 'Performance stats',
+    feature12_6: 'Scalability',
+
+    // Service features - Analytical AI Agent
+    feature13_1: 'Automated data processing',
+    feature13_2: 'Interactive dashboards',
+    feature13_3: 'Trend forecasting',
+    feature13_4: 'Report export',
+    feature13_5: 'BI systems integration',
+    feature13_6: 'Large data support',
+
+    // Service features - Content Generator
+    feature14_1: 'Fast article creation',
+    feature14_2: 'SEO-optimized texts',
+    feature14_3: 'Various content genres',
+    feature14_4: 'CMS integration',
+    feature14_5: 'Tone of voice settings',
+    feature14_6: 'Product descriptions',
+
+    // Service features - Virtual Assistant
+    feature15_1: 'Voice and text control',
+    feature15_2: 'Reminders and calendar',
+    feature15_3: 'Appointment booking',
+    feature15_4: 'FAQ answers',
+    feature15_5: 'Smartphone sync',
+    feature15_6: 'Personalized tips',
+
+    // Service features - Monitoring Agent
+    feature16_1: 'Website traffic tracking',
+    feature16_2: 'Social media analysis',
+    feature16_3: 'Sales monitoring',
+    feature16_4: 'Anomaly alerts',
+    feature16_5: 'Real-time reports',
+    feature16_6: 'Analytics integration',
+
     // Project Description
     projectDescription: 'Project Description',
     technologies: 'Technologies',
@@ -917,6 +1037,18 @@ const translations = {
     portfolioSiteDescription: 'Персональный сайт для демонстрации ваших работ и достижений',
     mediaPortalTitle: 'Медиа-портал',
     mediaPortalDescription: 'Новостной портал или блог с системою публикаций и комментариев',
+    aiChatAgentTitle: 'AI-чат-агент',
+    aiChatAgentDescription: 'Мультиканальный чат-бот для обработки запросов клиентов в реальном времени с интеграцией в мессенджеры и CRM',
+    recommendationAgentTitle: 'Рекомендательный агент',
+    recommendationAgentDescription: 'Система персонализированных рекомендаций товаров или контента на основе поведения пользователей',
+    analyticsAgentTitle: 'Аналитический AI-агент',
+    analyticsAgentDescription: 'Автоматизированная обработка и визуализация больших данных с прогнозами и отчетностью',
+    contentGeneratorTitle: 'Контент-генератор',
+    contentGeneratorDescription: 'AI-инструмент для создания статей, описаний товаров и маркетинговых текстов',
+    virtualAssistantTitle: 'Виртуальный ассистент',
+    virtualAssistantDescription: 'Голосовой или текстовый агент для бронирования, напоминаний и базовых консультаций',
+    monitoringAgentTitle: 'Мониторинговый агент',
+    monitoringAgentDescription: 'Система отслеживания ключевых метрик (сайт, соцсети, продажи) с мгновенными уведомлениями',
 
     // Additional Services
     logoDesignTitle: 'Дизайн логотипа',
@@ -1106,6 +1238,54 @@ const translations = {
     feature6_4: 'Рассылка новостей',
     feature6_5: 'Социальные сети',
     feature6_6: 'Пошук по сайту',
+
+    // Service features - AI Chat Agent
+    feature11_1: 'Мгновенные ответы 24/7',
+    feature11_2: 'Интеграция с мессенджерами',
+    feature11_3: 'Поддержка нескольких языков',
+    feature11_4: 'Аналитика запросов',
+    feature11_5: 'Простая настройка сценариев',
+    feature11_6: 'Связь с CRM',
+
+    // Service features - Recommendation Agent
+    feature12_1: 'Персонализированные рекомендации',
+    feature12_2: 'Анализ поведения пользователей',
+    feature12_3: 'Интеграция с каталогом',
+    feature12_4: 'Гибкие правила',
+    feature12_5: 'Статистика эффективности',
+    feature12_6: 'Масштабируемость',
+
+    // Service features - Analytical AI Agent
+    feature13_1: 'Автоматическая обработка данных',
+    feature13_2: 'Интерактивные дашборды',
+    feature13_3: 'Прогнозирование трендов',
+    feature13_4: 'Экспорт отчетов',
+    feature13_5: 'Интеграция с BI системами',
+    feature13_6: 'Поддержка больших данных',
+
+    // Service features - Content Generator
+    feature14_1: 'Быстрое создание статей',
+    feature14_2: 'SEO-оптимизированные тексты',
+    feature14_3: 'Разные жанры контента',
+    feature14_4: 'Интеграция с CMS',
+    feature14_5: 'Настройка тона голоса',
+    feature14_6: 'Генерация описаний товаров',
+
+    // Service features - Virtual Assistant
+    feature15_1: 'Голосовое и текстовое управление',
+    feature15_2: 'Напоминания и календарь',
+    feature15_3: 'Бронирование встреч',
+    feature15_4: 'Ответы на FAQ',
+    feature15_5: 'Синхронизация со смартфоном',
+    feature15_6: 'Персонализированные советы',
+
+    // Service features - Monitoring Agent
+    feature16_1: 'Отслеживание трафика сайта',
+    feature16_2: 'Анализ соцсетей',
+    feature16_3: 'Контроль продаж',
+    feature16_4: 'Сигналы при отклонениях',
+    feature16_5: 'Отчеты в реальном времени',
+    feature16_6: 'Интеграция с аналитикой',
 
     // Project Description
     projectDescription: 'Описание проекта',

--- a/src/pages/ServiceDetail.tsx
+++ b/src/pages/ServiceDetail.tsx
@@ -48,7 +48,13 @@ const ServiceDetail: React.FC = () => {
       '3': t('landingPageTitle'),
       '4': t('corporateWebsiteTitle'),
       '5': t('portfolioSiteTitle'),
-      '6': t('mediaPortalTitle')
+      '6': t('mediaPortalTitle'),
+      '11': t('aiChatAgentTitle'),
+      '12': t('recommendationAgentTitle'),
+      '13': t('analyticsAgentTitle'),
+      '14': t('contentGeneratorTitle'),
+      '15': t('virtualAssistantTitle'),
+      '16': t('monitoringAgentTitle')
     };
     return titles[serviceId] || service.title;
   };
@@ -60,7 +66,13 @@ const ServiceDetail: React.FC = () => {
       '3': t('landingPageDescription'),
       '4': t('corporateWebsiteDescription'),
       '5': t('portfolioSiteDescription'),
-      '6': t('mediaPortalDescription')
+      '6': t('mediaPortalDescription'),
+      '11': t('aiChatAgentDescription'),
+      '12': t('recommendationAgentDescription'),
+      '13': t('analyticsAgentDescription'),
+      '14': t('contentGeneratorDescription'),
+      '15': t('virtualAssistantDescription'),
+      '16': t('monitoringAgentDescription')
     };
     return descriptions[serviceId] || service.description;
   };
@@ -114,6 +126,54 @@ const ServiceDetail: React.FC = () => {
         t('feature6_4'),
         t('feature6_5'),
         t('feature6_6')
+      ],
+      '11': [
+        t('feature11_1'),
+        t('feature11_2'),
+        t('feature11_3'),
+        t('feature11_4'),
+        t('feature11_5'),
+        t('feature11_6')
+      ],
+      '12': [
+        t('feature12_1'),
+        t('feature12_2'),
+        t('feature12_3'),
+        t('feature12_4'),
+        t('feature12_5'),
+        t('feature12_6')
+      ],
+      '13': [
+        t('feature13_1'),
+        t('feature13_2'),
+        t('feature13_3'),
+        t('feature13_4'),
+        t('feature13_5'),
+        t('feature13_6')
+      ],
+      '14': [
+        t('feature14_1'),
+        t('feature14_2'),
+        t('feature14_3'),
+        t('feature14_4'),
+        t('feature14_5'),
+        t('feature14_6')
+      ],
+      '15': [
+        t('feature15_1'),
+        t('feature15_2'),
+        t('feature15_3'),
+        t('feature15_4'),
+        t('feature15_5'),
+        t('feature15_6')
+      ],
+      '16': [
+        t('feature16_1'),
+        t('feature16_2'),
+        t('feature16_3'),
+        t('feature16_4'),
+        t('feature16_5'),
+        t('feature16_6')
       ]
     };
     return features[serviceId] || [];
@@ -126,7 +186,13 @@ const ServiceDetail: React.FC = () => {
       '3': { projects: '300+', conversion: '28%', avgTime: t('days7') },
       '4': { projects: '200+', conversion: '15%', avgTime: t('days14') },
       '5': { projects: '120+', conversion: '22%', avgTime: t('days10') },
-      '6': { projects: '80+', conversion: '18%', avgTime: t('days30') }
+      '6': { projects: '80+', conversion: '18%', avgTime: t('days30') },
+      '11': { projects: '60+', conversion: '90%', avgTime: t('days25') },
+      '12': { projects: '40+', conversion: '85%', avgTime: t('days30') },
+      '13': { projects: '30+', conversion: '88%', avgTime: t('days35') },
+      '14': { projects: '75+', conversion: '92%', avgTime: t('days25') },
+      '15': { projects: '50+', conversion: '80%', avgTime: t('days30') },
+      '16': { projects: '90+', conversion: '95%', avgTime: t('days14') }
     };
     return stats[serviceId] || { projects: '50+', conversion: '20%', avgTime: t('days14') };
   };

--- a/src/store/slices/servicesSlice.ts
+++ b/src/store/slices/servicesSlice.ts
@@ -66,6 +66,54 @@ const initialState: ServicesState = {
       category: 'main'
     },
     {
+      id: '11',
+      title: 'AI-чат-агент',
+      description: 'Мультиканальний чат-бот для обробки запитів клієнтів у реальному часі з інтеграцією у месенджери та CRM.',
+      originalPrice: 45000,
+      discountPrice: 22500,
+      category: 'main'
+    },
+    {
+      id: '12',
+      title: 'Рекомендаційний агент',
+      description: 'Система персоналізованих рекомендацій товарів чи контенту на основі поведінки користувачів.',
+      originalPrice: 60000,
+      discountPrice: 30000,
+      category: 'main'
+    },
+    {
+      id: '13',
+      title: 'Аналітичний AI-агент',
+      description: 'Автоматизована обробка та візуалізація великих даних із прогнозами й звітністю.',
+      originalPrice: 70000,
+      discountPrice: 35000,
+      category: 'main'
+    },
+    {
+      id: '14',
+      title: 'Контент-генератор',
+      description: 'AI-інструмент для створення статей, описів товарів та маркетингових текстів.',
+      originalPrice: 25000,
+      discountPrice: 12500,
+      category: 'main'
+    },
+    {
+      id: '15',
+      title: 'Віртуальний асистент',
+      description: 'Голосовий або текстовий агент для бронювання, нагадувань і базових консультацій.',
+      originalPrice: 55000,
+      discountPrice: 27500,
+      category: 'main'
+    },
+    {
+      id: '16',
+      title: 'Моніторинговий агент',
+      description: 'Система відстеження ключових метрик (сайт, соцмережі, продажі) з миттєвими сповіщеннями.',
+      originalPrice: 35000,
+      discountPrice: 17500,
+      category: 'main'
+    },
+    {
       id: '7',
       title: 'Логотип',
       description: 'Розробка логотипу з унікальною ідеєю, адаптивного до всіх носіїв: від візиток до сайту.',


### PR DESCRIPTION
## Summary
- expand services list with AI agent offerings
- include translations for new services in all languages
- map new services in header, cards and detail page
- provide features and stats for new AI services

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857cfaa6664832d96f62ac65fa99945