### PR TITLE
Add UI animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "taos": "^1.0.3",
     "vaul": "^0.9.3",
     "zod": "^3.23.8"
   },

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -98,7 +98,7 @@ const Contact: React.FC = () => {
               </h3>
               
               <form onSubmit={handleSubmit} className="space-y-6">
-                <div>
+                <div className="animate-fade-in" style={{ animationDelay: '0ms' }}>
                   <label htmlFor="name" className="block text-gray-300 mb-2">
                     {t('nameLabel')} *
                   </label>
@@ -114,7 +114,7 @@ const Contact: React.FC = () => {
                   />
                 </div>
 
-                <div>
+                <div className="animate-fade-in" style={{ animationDelay: '100ms' }}>
                   <label htmlFor="email" className="block text-gray-300 mb-2">
                     {t('emailLabel')} *
                   </label>
@@ -130,7 +130,7 @@ const Contact: React.FC = () => {
                   />
                 </div>
 
-                <div>
+                <div className="animate-fade-in" style={{ animationDelay: '200ms' }}>
                   <label htmlFor="phone" className="block text-gray-300 mb-2">
                     {t('phoneLabel')}
                   </label>
@@ -145,7 +145,7 @@ const Contact: React.FC = () => {
                   />
                 </div>
 
-                <div>
+                <div className="animate-fade-in" style={{ animationDelay: '300ms' }}>
                   <label htmlFor="message" className="block text-gray-300 mb-2">
                     {t('messageLabel')} *
                   </label>
@@ -163,7 +163,8 @@ const Contact: React.FC = () => {
 
                 <button
                   type="submit"
-                  className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 rounded-lg hover:from-blue-600 hover:to-purple-700 transition-all duration-300 transform hover:scale-105 font-medium"
+                  className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 rounded-lg transition-transform duration-300 hover:-translate-y-1 hover:scale-105 hover:from-blue-600 hover:to-purple-700 animate-fade-in"
+                  style={{ animationDelay: '400ms' }}
                 >
                   {t('sendButton')}
                 </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -90,15 +90,15 @@ const Header: React.FC = () => {
 
           {/* Desktop Navigation */}
           <nav className="hidden lg:flex items-center space-x-8">
-            <button 
+            <button
               onClick={() => scrollToSection('hero')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('home')}
             </button>
-            <button 
+            <button
               onClick={() => scrollToSection('about')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('about')}
             </button>
@@ -109,7 +109,7 @@ const Header: React.FC = () => {
               onMouseEnter={() => setIsServicesOpen(true)}
               onMouseLeave={() => setIsServicesOpen(false)}
             >
-              <button className="flex items-center text-white hover:text-blue-400 transition-colors">
+              <button className="group relative flex items-center text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full">
                 {t('services')}
                 <ChevronDown className="ml-1 w-4 h-4" />
               </button>
@@ -136,33 +136,33 @@ const Header: React.FC = () => {
               )}
             </div>
 
-            <button 
+            <button
               onClick={() => scrollToSection('portfolio')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('portfolio')}
             </button>
-            <button 
+            <button
               onClick={() => scrollToSection('calculator')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('calculator')}
             </button>
-            <button 
+            <button
               onClick={() => scrollToSection('faq')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('faq')}
             </button>
-            <button 
+            <button
               onClick={() => scrollToSection('testimonials')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('testimonials')}
             </button>
-            <button 
+            <button
               onClick={() => scrollToSection('contact')}
-              className="text-white hover:text-blue-400 transition-colors"
+              className="group relative text-white transition-all duration-300 hover:text-blue-400 after:absolute after:left-0 after:-bottom-0.5 after:h-0.5 after:w-0 after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full"
             >
               {t('contacts')}
             </button>
@@ -171,9 +171,9 @@ const Header: React.FC = () => {
           {/* Language Selector & CTA Button */}
           <div className="hidden lg:flex items-center space-x-4">
             <LanguageSelector />
-            <button 
+            <button
               onClick={() => scrollToSection('contact')}
-              className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-2 rounded-full hover:from-blue-600 hover:to-purple-700 transition-all duration-300 transform hover:scale-105"
+              className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-2 rounded-full transition-transform duration-300 hover:-translate-y-1 hover:scale-105 hover:from-blue-600 hover:to-purple-700"
             >
               {t('getConsultation')}
             </button>
@@ -258,9 +258,9 @@ const Header: React.FC = () => {
               >
                 {t('contacts')}
               </button>
-              <button 
+              <button
                 onClick={() => scrollToSection('contact')}
-                className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-2 rounded-full hover:from-blue-600 hover:to-purple-700 transition-all duration-300 mt-4"
+                className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-2 rounded-full mt-4 transition-transform duration-300 hover:-translate-y-1 hover:scale-105 hover:from-blue-600 hover:to-purple-700"
               >
                 {t('getConsultation')}
               </button>

--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -59,7 +59,7 @@ const HeroSlider: React.FC = () => {
   };
 
   return (
-    <section className="min-h-screen flex items-center justify-center relative overflow-hidden font-poppins">
+    <section className="min-h-screen flex items-center justify-center relative overflow-hidden font-poppins animate-fade-in">
       {/* Enhanced Background with mesh gradient */}
       <div className={`absolute inset-0 bg-gradient-to-br ${slides[currentSlide].bgGradient} transition-all duration-1000`}>
         {/* Animated Background Elements with more variety */}
@@ -92,7 +92,10 @@ const HeroSlider: React.FC = () => {
             </span>
           </h1>
           
-          <p className="text-xl md:text-2xl lg:text-3xl text-gray-100 mb-10 leading-relaxed max-w-4xl mx-auto animate-fade-in-up font-light" style={{ animationDelay: '0.2s' }}>
+          <p
+            className="text-xl md:text-2xl lg:text-3xl text-gray-100 mb-10 leading-relaxed max-w-4xl mx-auto overflow-hidden whitespace-nowrap border-r-2 border-gray-100 animate-typing font-light"
+            style={{ animationDelay: '0.2s' }}
+          >
             {slides[currentSlide].subtitle}
           </p>
           

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -213,13 +213,20 @@ const Portfolio: React.FC = () => {
               style={{ transitionDelay: `${index * 100}ms` }}
             >
               <GlassCard className="group overflow-hidden hover:shadow-2xl hover:shadow-neon-blue/20 transform hover:scale-105 transition-all duration-500">
-                <div className="relative overflow-hidden">
-                  <img 
-                    src={item.image} 
+                <div className="relative overflow-hidden group">
+                  <img
+                    src={item.image}
                     alt={item.title}
                     className="w-full h-64 object-cover object-top transition-transform duration-500 group-hover:scale-110"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-gray-900/90 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <button
+                      onClick={() => openModal(item)}
+                      className="px-4 py-2 bg-gradient-to-r from-neon-blue to-neon-purple text-white rounded-lg font-medium hover:from-neon-purple hover:to-neon-pink transition-transform duration-300 hover:-translate-y-1 hover:scale-105"
+                    >
+                      {t('detailsButton')}
+                    </button>
+                  </div>
                   <div className="absolute top-4 right-4">
                     <GlassCard className="px-3 py-1">
                       <span className="text-neon-blue text-sm font-medium">
@@ -233,18 +240,9 @@ const Portfolio: React.FC = () => {
                   <h3 className="text-xl font-bold text-white mb-3 group-hover:text-neon-blue transition-colors">
                     {item.title}
                   </h3>
-                  <p className="text-gray-300 mb-4 leading-relaxed font-light">
+                  <p className="text-gray-300 leading-relaxed font-light">
                     {item.description}
                   </p>
-                  
-                  <div className="flex items-center justify-center">
-                    <button
-                      onClick={() => openModal(item)}
-                      className="px-4 py-2 bg-gradient-to-r from-neon-blue to-neon-purple text-white rounded-lg font-medium hover:from-neon-purple hover:to-neon-pink transition-all duration-300"
-                    >
-                      {t('detailsButton')}
-                    </button>
-                  </div>
                 </div>
               </GlassCard>
             </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -70,7 +70,10 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service, isLarge = true }) =>
   };
 
   return (
-    <div className={`bg-gradient-to-br from-gray-800 to-gray-900 p-8 rounded-2xl border border-gray-700 hover:border-blue-500/50 transition-all duration-300 transform hover:scale-105 group ${isLarge ? 'h-full' : ''}`}>
+    <div
+      data-taos="fade-up"
+      className={`bg-gradient-to-br from-gray-800 to-gray-900 p-8 rounded-2xl border border-gray-700 hover:border-blue-500/50 transition-all duration-300 transform hover:scale-105 group ${isLarge ? 'h-full' : ''}`}
+    >
       <h3 className={`font-bold text-white mb-4 group-hover:text-blue-400 transition-colors ${isLarge ? 'text-2xl' : 'text-xl'}`}>
         {getServiceTitle(service.id)}
       </h3>
@@ -95,13 +98,13 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service, isLarge = true }) =>
       <div className="space-y-3">
         <button 
           onClick={handleViewDetails}
-          className="w-full bg-gradient-to-r from-gray-600 to-gray-700 text-white py-3 rounded-lg hover:from-gray-500 hover:to-gray-600 transition-all duration-300 transform hover:scale-105 font-medium"
+          className="w-full bg-gradient-to-r from-gray-600 to-gray-700 text-white py-3 rounded-lg hover:from-gray-500 hover:to-gray-600 transition-transform duration-300 hover:-translate-y-1 hover:scale-105 font-medium"
         >
           {t('detailsButton')}
         </button>
         <button 
           onClick={() => scrollToSection('contact')}
-          className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 rounded-lg hover:from-blue-600 hover:to-purple-700 transition-all duration-300 transform hover:scale-105 font-medium"
+          className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 rounded-lg hover:from-blue-600 hover:to-purple-700 transition-transform duration-300 hover:-translate-y-1 hover:scale-105 font-medium"
         >
           {t('orderNow')}
         </button>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -73,8 +73,9 @@ const Testimonials: React.FC = () => {
           <div className="relative">
             {/* Main testimonial */}
             <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-8 md:p-12 rounded-2xl border border-gray-700 text-center min-h-[300px] flex flex-col justify-center">
-              <div className="text-6xl mb-4">
-                {testimonials[currentIndex].avatar}
+              <div className="relative mb-4 flex items-center justify-center w-20 h-20 mx-auto">
+                <span className="absolute inline-flex h-full w-full rounded-full bg-blue-500 opacity-75 animate-ping"></span>
+                <span className="relative text-6xl">{testimonials[currentIndex].avatar}</span>
               </div>
               
               <blockquote className="text-lg md:text-xl text-gray-300 leading-relaxed mb-6 italic">
@@ -138,7 +139,10 @@ const Testimonials: React.FC = () => {
               onClick={() => setCurrentIndex(index)}
             >
               <div className="flex items-center mb-4">
-                <span className="text-2xl mr-3">{testimonial.avatar}</span>
+                <span className="relative flex mr-3 w-8 h-8 items-center justify-center">
+                  <span className="absolute inline-flex h-full w-full rounded-full bg-blue-500 opacity-75 animate-ping"></span>
+                  <span className="relative text-2xl">{testimonial.avatar}</span>
+                </span>
                 <div>
                   <p className="text-white font-medium">{testimonial.name}</p>
                   <p className="text-gray-400 text-sm">{testimonial.position}</p>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,9 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import 'taos/style.css'
+import taos from 'taos'
 import './index.css'
+
+taos.init()
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -109,15 +109,19 @@ export default {
 						boxShadow: '0 0 40px rgba(59, 130, 246, 0.8)'
 					}
 				},
-				'shimmer': {
-					'0%': {
-						backgroundPosition: '-200% 0'
-					},
-					'100%': {
-						backgroundPosition: '200% 0'
-					}
-				},
-				'fade-in-up': {
+                               'shimmer': {
+                                       '0%': {
+                                               backgroundPosition: '-200% 0'
+                                       },
+                                       '100%': {
+                                               backgroundPosition: '200% 0'
+                                       }
+                               },
+                               'fade-in': {
+                                       '0%': { opacity: '0' },
+                                       '100%': { opacity: '1' }
+                               },
+                               'fade-in-up': {
 					'0%': {
 						opacity: '0',
 						transform: 'translateY(30px)'
@@ -179,8 +183,9 @@ export default {
 				'accordion-up': 'accordion-up 0.2s ease-out',
 				'float': 'float 6s ease-in-out infinite',
 				'glow': 'glow 2s ease-in-out infinite alternate',
-				'shimmer': 'shimmer 2s linear infinite',
-				'fade-in-up': 'fade-in-up 0.6s ease-out',
+                               'shimmer': 'shimmer 2s linear infinite',
+                               'fade-in': 'fade-in 0.5s ease-out',
+                               'fade-in-up': 'fade-in-up 0.6s ease-out',
 				'fade-in-down': 'fade-in-down 0.6s ease-out',
 				'slide-in-left': 'slide-in-left 0.6s ease-out',
 				'scale-in': 'scale-in 0.5s ease-out',


### PR DESCRIPTION
## Summary
- animate hero section fade in
- add taos animations for service cards
- style menu items with underline on hover
- add typewriter effect for hero subtitles
- update CTA buttons and testimonials
- show details button on portfolio hover
- stagger contact form animations
- expose TAOS library initialization
- configure new fade-in keyframes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588c4eeaa8832daf51cdf6b8a0e554