### PR TITLE
Fix taos stylesheet path

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
-import 'taos/style.css'
+import 'taos/dist/style.css'
 import taos from 'taos'
 import './index.css'
 


### PR DESCRIPTION
## Summary
- correct the import path for the taos stylesheet

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685890e9167c832dbc75632d9f505b75