### PR TITLE
Configure TAOS plugin

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
-import 'taos/dist/style.css'
 import taos from 'taos'
 import './index.css'
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,12 +3,16 @@ import type { Config } from "tailwindcss";
 
 export default {
 	darkMode: ["class"],
-	content: [
-		"./pages/**/*.{ts,tsx}",
-		"./components/**/*.{ts,tsx}",
-		"./app/**/*.{ts,tsx}",
-		"./src/**/*.{ts,tsx}",
-	],
+       content: [
+               "./pages/**/*.{ts,tsx}",
+               "./components/**/*.{ts,tsx}",
+               "./app/**/*.{ts,tsx}",
+               "./src/**/*.{ts,tsx}",
+       ],
+       transform: {
+               tsx: (content: string) => content.replace(/taos:/g, ""),
+       },
+       safelist: [{ pattern: /taos:.*/ }],
 	prefix: "",
 	theme: {
 		container: {
@@ -200,5 +204,8 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [
+               require("tailwindcss-animate"),
+               require("taos/plugin"),
+       ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- drop nonexistent TAOS CSS import
- enable TAOS plugin in Tailwind config with transform and safelist

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685892b43814832db07d5e6a2760e8f9