### PR TITLE
Configure TAOS plugin with Tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "taos": "^1.0.3",
     "vaul": "^0.9.3",
     "zod": "^3.23.8"
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import taos from 'taos'
 import './index.css'
+
+taos.init()
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,11 +3,15 @@ import type { Config } from "tailwindcss";
 
 export default {
 	darkMode: ["class"],
-       content: [
-               "./pages/**/*.{ts,tsx}",
-               "./components/**/*.{ts,tsx}",
-               "./app/**/*.{ts,tsx}",
-               "./src/**/*.{ts,tsx}",
+       content: {
+               relative: true,
+               transform: (content: string) => content.replace(/taos:/g, ''),
+               files: ['./src/**/*.{js,jsx,ts,tsx,html}'],
+       },
+       safelist: [
+               '!duration-[0ms]',
+               '!delay-[0ms]',
+               'html.js :where([class*="taos:"]:not(.taos-init))'
        ],
        prefix: "",
 	theme: {
@@ -202,5 +206,6 @@ export default {
 	},
        plugins: [
                require("tailwindcss-animate"),
+               require("taos/plugin"),
        ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add `taos` dependency
- enable TAOS JIT config in `tailwind.config.ts`
- init TAOS in `main.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685896a42f64832db8b262c60228ac48