### PR TITLE
Configure TAOS via CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,14 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Poppins:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <script>document.documentElement.classList.add('js')</script>
+    <script src="https://unpkg.com/taos@latest/dist/taos.umd.js"></script>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      taos.init()
+    </script>
   </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
-import taos from 'taos'
 import './index.css'
 
-taos.init()
 
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- load TAOS from CDN instead of bundling its JS
- initialize TAOS in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685897de5c5c832db4dbefe1b5bcdc1f