### PR TITLE
Fix puppeteer launch for react-snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview"
   },
   "reactSnap": {
-    "include": ["/", "/service/ecommerce", "/service/educational"]
+    "include": ["/", "/service/ecommerce", "/service/educational"],
+    "puppeteerArgs": ["--no-sandbox", "--disable-setuid-sandbox"]
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- disable Chrome sandbox for react-snap to allow running as root

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-snap)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc6269884832dbfc9b47f51224cc7