### PR TITLE
Fix react-snap postbuild path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "reactSnap": {
+    "source": "dist",
     "include": ["/", "/service/ecommerce", "/service/educational"],
     "puppeteerArgs": ["--no-sandbox", "--disable-setuid-sandbox"]
   },


### PR DESCRIPTION
## Summary
- configure react-snap to look for the Vite `dist` folder

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc7951a70832db72b9ad6986be93a